### PR TITLE
Fix Resource __repr__ method

### DIFF
--- a/killbill/resource.py
+++ b/killbill/resource.py
@@ -45,7 +45,7 @@ class Resource(object):
             setattr(self, key, value)
 
     def __repr__(self):
-        return '%s %s' % (self.__class__, self.to_json)
+        return '%s %s' % (self.__class__, self.to_json())
 
     def build_options(self, **options):
         default = {


### PR DESCRIPTION
Hi,
if you print the Account object the python interpreter raise this exception.
RuntimeError: maximum recursion depth exceeded

This pull request fix the problem.

Best,

Federico